### PR TITLE
Exclude lua-Harness HTML files which skew repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/lang/lua-Harness/suite/public/* linguist-vendored


### PR DESCRIPTION
This change fixes GitHub language stats. Instead of this:
![image](https://user-images.githubusercontent.com/1285136/64250188-277d4380-cf1e-11e9-878c-f62b4d1e73e7.png)
We get this (see https://github.com/eliasdaler/luavela):
![image](https://user-images.githubusercontent.com/1285136/64250220-3e239a80-cf1e-11e9-8374-6fdda4227af7.png)

lua-Harness stores a lot of HTML files and .gitattributes allows us to ignore them.
Note that this change takes ~3-4 days to be applied to stats, so merging this PR won't give immediate result.