### PR TITLE
Exclude movtv and movtvpri from -O4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ version 0.24-dev0
   * Added configuration file for Travis CI
   * Added MOVTVPRI optimization, which extends MOVTV for recording-time nil, false and true values
   * Extended information about contributors
+  * Excluded movtv and movtvpri from -O4
 
 version 0.23-dev0
   * Added an ability to copy values between tables on-trace without guarded loads:

--- a/docs/public/pub-running-ujit.rst
+++ b/docs/public/pub-running-ujit.rst
@@ -139,14 +139,14 @@ Here are the available flags and at what optimization levels they are enabled: 
    ``dse``                      ✅    ✅         Dead-Store Elimination
    ``abc``                      ✅    ✅         Array Bounds Check Elimination
    ``sink``                     ✅    ✅         `Allocation Sinking Optimization <http://wiki.luajit.org/Allocation-Sinking-Optimization>`__
-   ``fuse``                                  ❗  Fusion of operands into instructions. This optimization is currently a no-op in |PROJECT| at the moment.
+   ``fuse``                                 ❗   Fusion of operands into instructions. This optimization is currently a no-op in |PROJECT| at the moment.
    ``nohrefk``                         ✅        Disables emission of the ``HREFK`` IR instruction. Available since |PROJECT| 0.10.
    ``noretl``                          ✅        Disables recording of returns to lower Lua frames. Available since |PROJECT| 0.10.
    ``jitcat``                          ✅        Enables compilation of concatenation. Available since |PROJECT| 0.11.
    ``jittabcat``                       ✅        Enables compilation of table.concat. Available since |PROJECT| 0.20.
    ``jitstr``                          ✅        Enables compilation of string.find, string.lower, string.upper. Available since |PROJECT| 0.20.
-   ``movtv``                           ✅        Optimizes copying data between tables. Available since |PROJECT| 0.23.
-   ``movtvpri``                        ✅        Same as ``movtv``, but for recording-time ``nil``, ``false`` and ``true`` values. Available since |PROJECT| 0.24.
+   ``movtv``                                ❗   Optimizes copying data between tables. Available since |PROJECT| 0.23.
+   ``movtvpri``                             ❗   Same as ``movtv``, but for recording-time ``nil``, ``false`` and ``true`` values. Available since |PROJECT| 0.24.
    ``jitpairs``                             ❗   Enables compilation of 'pairs' and 'next'. Available since |PROJECT| 0.22, but is known to produce incorrect results sometimes. Work on fix in progress.
    ============= ====== ====== ===== ===== ===== =======================================================
 

--- a/src/jit/lj_jit.h
+++ b/src/jit/lj_jit.h
@@ -90,9 +90,7 @@
                           JIT_F_OPT_NORETL    | \
                           JIT_F_OPT_JITCAT    | \
                           JIT_F_OPT_JITTABCAT | \
-                          JIT_F_OPT_JITSTR    | \
-                          JIT_F_OPT_MOVTV     | \
-                          JIT_F_OPT_MOVTVPRI)
+                          JIT_F_OPT_JITSTR)
 
 #define JIT_F_OPT_DEFAULT  JIT_F_OPT_3
 

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/apart-scalar.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/apart-scalar.lua
@@ -10,7 +10,7 @@ end
 local src = {"val1", 2, "val3", 4, "val5", 6}
 local dst = {}
 
-jit.opt.start(4, "hotloop=1", "hotexit=3")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=3")
 jit.on()
 
 mov(dst, src, 1)

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/apart.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/apart.lua
@@ -49,7 +49,7 @@ src[70] = function () end
 src[70 + 1] = function () end
 src[70 + 2] = function () end
 
-jit.opt.start(4, "hotloop=2", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=2", "hotexit=2")
 jit.on()
 
 for i = 1, N do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/fload-meta-guard.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/fload-meta-guard.lua
@@ -1,7 +1,7 @@
 -- This is a part of uJIT's testing suite.
 -- Copyright (C) 2015-2019 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 local setmetatable = setmetatable

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/gset.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/gset.lua
@@ -3,7 +3,7 @@
 
 local src = {"a", "b", "c", "d", "e", "f", "g", "h"}
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 
 -- If you want to change the name of the variable, tune .luacheckrc as well :-)
 FOO = nil

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-newref-meta-guard.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-newref-meta-guard.lua
@@ -15,7 +15,7 @@ local dst = {
 }
 assert(#src == #dst, "#src == #dst")
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-newref.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-newref.lua
@@ -14,7 +14,7 @@ local dst = {
 }
 assert(#src == #dst, "#SRC == #DST")
 
-jit.opt.start(4, "hotloop=1", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=2")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-no-newref-hoisting.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-no-newref-hoisting.lua
@@ -4,7 +4,7 @@
 local setmetatable = setmetatable
 local modules = {{}, {}, {}, {}, {}}
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 local function seeall(mod)

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-no-newref-partial.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-no-newref-partial.lua
@@ -6,7 +6,7 @@ jit.off()
 local src = {key1 = 1, key2 = 2, key3 = 3}
 local dst = {}
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 for _ = 1, 5 do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-no-newref.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/hpart-no-newref.lua
@@ -19,7 +19,7 @@ local dst = {
 }
 assert(#src == #dst, "#src == #dst")
 
-jit.opt.start(4, "hotloop=1", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=2")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/in-place.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/in-place.lua
@@ -6,7 +6,7 @@ local Q = {8, 7, 6, 5, 4, 3, 2, 1}
 local i = 1
 local j = #q
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 repeat

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-assert.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-assert.lua
@@ -4,7 +4,7 @@
 local src = {"a", "b", "c", "d", "e", "f", false, "h"}
 local dst = {}
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 
 for i = 1, #src do
     -- We do not record assert explicitly relying on the guarded load.

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-bc-isf.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-bc-isf.lua
@@ -5,7 +5,7 @@ local src = {"x", "y", false, false, false}
 local dst = {}
 local n = 0
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 
 for i = 1, #src do
     if src[i] then -- BC_ISF

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-bc-ist.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-bc-ist.lua
@@ -5,7 +5,7 @@ local src = {"x", "y", false, false, false}
 local dst = {}
 local n = 0
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 
 for i = 1, #src do
     if not src[i] then -- BC_IST

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-bc-not.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/load-used-by-bc-not.lua
@@ -5,7 +5,7 @@ local src = {"x", "y", false, false, false}
 local dst = {}
 local n = 0
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 
 for i = 1, #src do
     local flag = not src[i] -- BC_NOT

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/no-fuse-meta-dst.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/no-fuse-meta-dst.lua
@@ -21,7 +21,7 @@ end
 
 ujit.immutable(src) -- just in case
 
-jit.opt.start(4, "hotloop=1", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=2")
 jit.on()
 
 for i = 1, N do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/no-fuse-meta-src.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/no-fuse-meta-src.lua
@@ -16,7 +16,7 @@ for i = 1, N do
 	dst[i] = false
 end
 
-jit.opt.start(4, "hotloop=1", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=2")
 jit.on()
 
 for i = 1, N do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/pri-nil-empty.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/pri-nil-empty.lua
@@ -14,7 +14,7 @@ local src = {
 
 local dst = {}
 
-jit.opt.start(4, "hotloop=1", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=2")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/pri-nil-non-empty.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/pri-nil-non-empty.lua
@@ -14,7 +14,7 @@ local src = {
 
 local dst = {}
 
-jit.opt.start(4, "hotloop=1", "hotexit=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=2")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/pri-non-nil.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/pri-non-nil.lua
@@ -18,7 +18,7 @@ local src = {
 
 local dst = {}
 
-jit.opt.start(4, "hotloop=1", "hotexit=3")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1", "hotexit=3")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/same-table-diff-keys.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/same-table-diff-keys.lua
@@ -3,7 +3,7 @@
 
 local src = {{x=1}, {x=2}, {x=3}, {x=4}, {x=5}, {x=6}, {x=7}, {x=8}}
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/same-table-same-key.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/same-table-same-key.lua
@@ -4,7 +4,7 @@
 local src = {{x=1}, {x=2}, {x=3}, {x=4}, {x=5}, {x=6}, {x=7}, {x=8}}
 local ref = {{x=1}, {x=2}, {x=3}, {x=4}, {x=5}, {x=6}, {x=7}, {x=8}}
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 for i = 1, #src do

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/sload-meta-guard.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/sload-meta-guard.lua
@@ -1,7 +1,7 @@
 -- This is a part of uJIT's testing suite.
 -- Copyright (C) 2015-2019 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 local function mov_arr(src)
@@ -20,7 +20,7 @@ local src2 = ujit.immutable(setmetatable({
 	6, 5, 4, 3, 2, 1,
 }})))
 
-jit.opt.start(4, "hotloop=2")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=2")
 jit.on()
 
 local dst1 = mov_arr(src1)

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/tvload-meta-guard.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/movtv/tvload-meta-guard.lua
@@ -1,7 +1,7 @@
 -- This is a part of uJIT's testing suite.
 -- Copyright (C) 2015-2019 IPONWEB Ltd. See Copyright Notice in COPYRIGHT
 
-jit.opt.start(4, "hotloop=1")
+jit.opt.start(4, "movtv", "movtvpri", "hotloop=1")
 jit.on()
 
 local setmetatable = setmetatable


### PR DESCRIPTION
Unfortunately, it turned out that `movtv` and `motvpri` are not yet stable and cause crashes in some conditions, so they should be excluded from -O4 set of optimizations and are marked as WIP.