### PR TITLE
Backported fix for string.find recording

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ version 0.24-dev0
   * Added MOVTVPRI optimization, which extends MOVTV for recording-time nil, false and true values
   * Extended information about contributors
   * Excluded movtv and movtvpri from -O4
+  * Backported fix for string.find recording from tarantool/luajit repo
 
 version 0.23-dev0
   * Added an ability to copy values between tables on-trace without guarded loads:

--- a/src/jit/lj_ffrecord.c
+++ b/src/jit/lj_ffrecord.c
@@ -1073,8 +1073,12 @@ static void recff_string_find(jit_State *J, RecordFFData *rd)
                      str->len - (size_t)start, pat->len)) {
       TRef pos;
       emitir(IRTG(IR_NE, IRT_PTR), trfindptr, trnullptr);
-      pos = emitir(IRTI(IR_SUB), trfindptr,
-                   emitir(IRT(IR_STRREF, IRT_PTR), trstr, tr0));
+      /*
+       * Caveat: can't use STRREF trstr 0 here because that might be pointing
+       * into a wrong string due to folding.
+       */
+      pos = emitir(IRTI(IR_ADD), trstart,
+                   emitir(IRTI(IR_SUB), trfindptr, trsptr));
       J->base[0] = emitir(IRTI(IR_ADD), pos, lj_ir_kint(J, 1));
       J->base[1] = emitir(IRTI(IR_ADD), pos, trplen);
       rd->nres = 2;

--- a/tests/impl/uJIT-tests-Lua/suite/chunks/string/find-fold-bug.lua
+++ b/tests/impl/uJIT-tests-Lua/suite/chunks/string/find-fold-bug.lua
@@ -1,0 +1,11 @@
+-- Test file to demonstrate Lua fold machinery incorrect behavior, details:
+--     https://github.com/LuaJIT/LuaJIT/issues/505
+
+jit.opt.start("hotloop=1", 'jitcat', 'jitstr')
+for _ = 1, 20 do
+    local value = "abc"
+    local pos_c = string.find(value, "c", 1, true)
+    local value2 = string.sub(value, 1, pos_c - 1)
+    local pos_b = string.find(value2, "b", 2, true)
+    assert(pos_b == 2, "FAIL: position of 'b' is " .. pos_b)
+end

--- a/tests/impl/uJIT-tests-Lua/suite/string.t
+++ b/tests/impl/uJIT-tests-Lua/suite/string.t
@@ -107,3 +107,8 @@ $tester->run('bufstr-const-fold.lua', args => '-p-')
     ->stdout_has_no(qr/TRACE.+?abort.+?/)
     ->stdout_has_no(q/BUFSTR/)  # all BUFSTRs were folded away
 ;
+
+$tester->run('find-fold-bug.lua', args => '-p-')
+    ->exit_ok
+    ->stdout_has_no(qr/TRACE.+?abort.?/)
+;


### PR DESCRIPTION
This is a squashed changeset of the following commits from
tarantool/luajit repo:
* [587532e](https://github.com/tarantool/luajit/commit/587532e66ab447728be8a0a23fd8a3ef4f623661)
* [98b1cfc](https://github.com/tarantool/luajit/commit/98b1cfcc00f49d7c55e97c4aab57ab7c5aa7799a)

Relates to [LuaJIT gh-505](https://github.com/LuaJIT/LuaJIT/issues/505)