### PR TITLE
Use separate sets of object files for static and shared libs

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -17,7 +17,7 @@ set(UDIS86_DIR "${CMAKE_CURRENT_SOURCE_DIR}/udis86")
 
 list(APPEND THIRD_PARTY_INCLUDE ${UDIS86_DIR})
 
-add_library(libudis86 OBJECT
+set(UDIS86_SOURCES
   ${UDIS86_DIR}/libudis86/decode.c
   ${UDIS86_DIR}/libudis86/itab.c
   ${UDIS86_DIR}/libudis86/syn.c
@@ -25,17 +25,20 @@ add_library(libudis86 OBJECT
   ${UDIS86_DIR}/libudis86/syn-intel.c
   ${UDIS86_DIR}/libudis86/udis86.c)
 
-# Fix-ups to avoid patching sources while keeping compilers and linkers happy:
+# Fix-ups to avoid patching sources while keeping compilers happy:
 
-target_compile_options(libudis86
- # All fallthrough cases are documented and shouldn't trigger warnings:
- PRIVATE "-Wno-implicit-fallthrough")
+# All fallthrough cases are documented and shouldn't trigger warnings:
+set_source_files_properties(${UDIS86_DIR}/libudis86/decode.c
+  PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
 
 # Pretend we have run autoconf for real:
-target_compile_definitions(libudis86 PRIVATE HAVE_STRING_H)
+set_source_files_properties(${UDIS86_DIR}/libudis86/udis86.c
+  PROPERTIES COMPILE_DEFINITIONS HAVE_STRING_H)
 
-# Otherwise we have some linking problems:
-set_target_properties(libudis86 PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_library(libudis86_static OBJECT ${UDIS86_SOURCES})
+add_library(libudis86_shared OBJECT ${UDIS86_SOURCES})
+
+set_target_properties(libudis86_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 #
 # jemalloc
@@ -50,7 +53,7 @@ if(UJIT_ALLOCATOR STREQUAL "jemalloc")
     set(JEMALLOC_SOURCE_DIR ${JEMALLOC_DIR}) # this will make ExternalProject build in-source
   endif()
 
-  ExternalProject_Add(jemalloc_ext
+  ExternalProject_Add(jemalloc
     PREFIX jemalloc-5.0.1
     URL ${JEMALLOC_URL} # jemalloc source directory, gets copied to build dir in out-of-source build
     SOURCE_DIR ${JEMALLOC_SOURCE_DIR}
@@ -62,9 +65,39 @@ if(UJIT_ALLOCATOR STREQUAL "jemalloc")
     INSTALL_COMMAND cmake -E echo "Skipping install step"
   )
 
-  ExternalProject_Get_Property(jemalloc_ext SOURCE_DIR)
+  ExternalProject_Get_Property(jemalloc SOURCE_DIR)
   set(JEMALLOC_OBJ_DIR ${SOURCE_DIR}/src)
   set(JEMALLOC_OBJ
+    ${JEMALLOC_OBJ_DIR}/jemalloc.o
+    ${JEMALLOC_OBJ_DIR}/arena.o
+    ${JEMALLOC_OBJ_DIR}/background_thread.o
+    ${JEMALLOC_OBJ_DIR}/base.o
+    ${JEMALLOC_OBJ_DIR}/bitmap.o
+    ${JEMALLOC_OBJ_DIR}/ckh.o
+    ${JEMALLOC_OBJ_DIR}/ctl.o
+    ${JEMALLOC_OBJ_DIR}/extent.o
+    ${JEMALLOC_OBJ_DIR}/extent_dss.o
+    ${JEMALLOC_OBJ_DIR}/extent_mmap.o
+    ${JEMALLOC_OBJ_DIR}/hash.o
+    ${JEMALLOC_OBJ_DIR}/hooks.o
+    ${JEMALLOC_OBJ_DIR}/large.o
+    ${JEMALLOC_OBJ_DIR}/malloc_io.o
+    ${JEMALLOC_OBJ_DIR}/mutex.o
+    ${JEMALLOC_OBJ_DIR}/mutex_pool.o
+    ${JEMALLOC_OBJ_DIR}/nstime.o
+    ${JEMALLOC_OBJ_DIR}/pages.o
+    ${JEMALLOC_OBJ_DIR}/prng.o
+    ${JEMALLOC_OBJ_DIR}/prof.o
+    ${JEMALLOC_OBJ_DIR}/rtree.o
+    ${JEMALLOC_OBJ_DIR}/stats.o
+    ${JEMALLOC_OBJ_DIR}/spin.o
+    ${JEMALLOC_OBJ_DIR}/sz.o
+    ${JEMALLOC_OBJ_DIR}/tcache.o
+    ${JEMALLOC_OBJ_DIR}/ticker.o
+    ${JEMALLOC_OBJ_DIR}/tsd.o
+    ${JEMALLOC_OBJ_DIR}/witness.o
+  )
+  set(JEMALLOC_OBJ_PIC
     ${JEMALLOC_OBJ_DIR}/jemalloc.pic.o
     ${JEMALLOC_OBJ_DIR}/arena.pic.o
     ${JEMALLOC_OBJ_DIR}/background_thread.pic.o
@@ -96,9 +129,17 @@ if(UJIT_ALLOCATOR STREQUAL "jemalloc")
   )
   list(APPEND THIRD_PARTY_INCLUDE ${SOURCE_DIR}/include)
 
-  add_library(jemalloc OBJECT IMPORTED GLOBAL)
-  set_target_properties(jemalloc PROPERTIES
+  add_library(jemalloc_static OBJECT IMPORTED GLOBAL)
+  add_dependencies (jemalloc_static jemalloc)
+  set_target_properties(jemalloc_static PROPERTIES
     IMPORTED_OBJECTS "${JEMALLOC_OBJ}"
+  )
+
+  add_library(jemalloc_shared OBJECT IMPORTED GLOBAL)
+  add_dependencies (jemalloc_shared jemalloc)
+  set_target_properties(jemalloc_shared PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    IMPORTED_OBJECTS "${JEMALLOC_OBJ_PIC}"
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,9 +141,11 @@ if(UJIT_ENABLE_VTUNEJIT)
     include_directories(${VTUNE_INSTALL_DIR}/include)
     # List of necessary files according to
     # https://software.intel.com/en-us/node/596668
-    set(SOURCES_VTUNE_SDK
+    set(VTUNE_SDK_SOURCES
       ${VTUNE_INSTALL_DIR}/sdk/src/ittnotify/jitprofiling.c
     )
+    # Suppress complaints about the code base we do not control:
+    set_source_files_properties(${VTUNE_SDK_SOURCES} PROPERTIES COMPILE_FLAGS -Wno-pedantic)
   else()
     message(FATAL_ERROR "VTune installation dir '${VTUNE_INSTALL_DIR}' not found.")
   endif()

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ version 0.24-dev0
   * Reworked building udis86 to use CMake instead of autoconf and libtool
   * Added a mini-suite of smoke tests to easily run sanity checks for the platform
   * Added support for macOS, tested with AppleClang 10 and 11 under macOS 10.13, 10.14, 10.15
+  * Enabled separate build of static and shared libraries
 
 version 0.23-dev0
   * Added an ability to copy values between tables on-trace without guarded loads:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -54,24 +54,32 @@ dependencies, which are not built by default.
 Building
 --------
 
-To trigger the build with default configuration, enter
+Both in source and out of source builds are supported, the latter is
+recommended. To trigger build with default configuration, please run:
 
- $ cmake . [...configuration flags...]
- $ make
+ $ mkdir luavela-build
+ $ cd luavela-build
+ $ cmake /path/to/luavela
+ $ make -j
 
-You can add VERBOSE=1 to the make command in order to get verbose Make output.
-Both a static and a shared library are built. Two CLIs are built too,
-respectively, but it is recommended to use the statically linked version.
-Libraries and binaries will be created in-source, i.e. 'src/ujit',
-'src/libujit.a', 'src/libujit.so', etc.
+You can add `VERBOSE=1` to the `make` command in order to get a verbose output.
+The build produces a static and a shared library in one go, so CMake's
+BUILD_SHARED_LIBS flag will probably be useless.
 
-All configuration flags should be passed in -DKEY=VALUE form. If KEY is a
-boolean flag, any cmake-compatible boolean value can be used as VALUE (i.e.
+Two CLIs are built too (one that links to the static library, and the other one
+with dynamic linking), it is recommended to use the statically linked version.
+
+Libraries and binaries are created in `luavela-build/src`.
+
+All CMake configuration flags should be passed in -DKEY=VALUE form. If KEY is a
+boolean flag, any CMake-compatible boolean value can be used as VALUE (i.e.
 1/0, ON/OFF, TRUE/FALSE). "ON" or "OFF" are used throughout this documentation
 for consistency. Example of triggering build with some flags defined:
 
- $ cmake . -DCMAKE_BUILD_TYPE=Debug
- $ make VERBOSE=1
+ $ mkdir luavela-build
+ $ cd luavela-build
+ $ cmake /path/to/luavela -DCMAKE_BUILD_TYPE=Debug
+ $ make -j VERBOSE=1
 
 Following configuration flags are supported:
 
@@ -92,11 +100,13 @@ CMAKE_INSTALL_PREFIX
 ^^^^^^^^^^^^^^^^^^^^
 
 Prefix for installing uJIT into your system. We do not set any explicit default
-resorting to the value provided by cmake. However, you almost definitely
-want something like this for packaging and production installs:
+resorting to the value provided by CMake. However, you almost definitely
+want something like this for production installs:
 
- $ cmake . -DCMAKE_INSTALL_PREFIX=/usr
- $ make package
+ $ cmake /path/to/luavela -DCMAKE_INSTALL_PREFIX=/usr
+ $ sudo make install
+
+If you have a CPack module, `make package` should be used for creating a package.
 
 UJIT_TEST_LIB_TYPE
 ^^^^^^^^^^^^^^^^^^
@@ -117,7 +127,7 @@ UJIT_TEST_OPTIONS
 
 A raw string of options to be passed to the uJIT binary during testing, e.g.:
 
- $ cmake . -DCMAKE_BUILD_TYPE=Debug -DUJIT_TEST_OPTIONS="-Xhashf=city"
+ $ cmake /path/to/luavela -DCMAKE_BUILD_TYPE=Debug -DUJIT_TEST_OPTIONS="-Xhashf=city"
 
 UJIT_HAS_JIT
 ^^^^^^^^^^^^

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,7 +225,7 @@ make_source_list(SOURCES_CORE_NO_JIT_FFI # Everything except FFI and JIT:
 set(SOURCES_CORE
   ${SOURCES_CORE_NO_JIT_FFI}
   # misc:
-  ${SOURCES_VTUNE_SDK}
+  ${VTUNE_SDK_SOURCES}
 )
 
 if(UJIT_HAS_JIT)
@@ -338,26 +338,27 @@ add_custom_target (
 # --- Generate core and VM object files ---------------------------------------
 
 ## Virtual machine
-add_library (vm OBJECT lj_vm.s)
-set_target_properties (vm PROPERTIES
-  POSITION_INDEPENDENT_CODE 1
-  COMPILE_FLAGS "${TARGET_VM_FLAGS}")
+add_library (vm_static OBJECT lj_vm.s)
+add_library (vm_shared OBJECT lj_vm.s)
+
+set_property (TARGET vm_shared APPEND PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property (TARGET vm_static vm_shared APPEND PROPERTY COMPILE_FLAGS "${TARGET_VM_FLAGS}")
+
 ## Platform core
-add_library (core OBJECT ${SOURCES_CORE})
-set_target_properties (core PROPERTIES
-  POSITION_INDEPENDENT_CODE 1
-  COMPILE_FLAGS "${TARGET_C_FLAGS}")
+add_library (core_static OBJECT ${SOURCES_CORE})
+add_library (core_shared OBJECT ${SOURCES_CORE})
 
-if (UJIT_ENABLE_VTUNEJIT)
-  # Suppress complaints about the code base we do not control:
-  set_source_files_properties(${SOURCES_VTUNE_SDK} PROPERTIES COMPILE_FLAGS -Wno-pedantic)
-endif()
+set_property (TARGET core_shared APPEND PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property (TARGET core_static core_shared APPEND PROPERTY COMPILE_FLAGS "${TARGET_C_FLAGS}")
 
-target_include_directories(core PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(core_static PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(core_shared PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-add_dependencies (core buildvm_output libudis86)
+add_dependencies (core_static buildvm_output libudis86_static)
+add_dependencies (core_shared buildvm_output libudis86_shared)
 if(UJIT_ALLOCATOR STREQUAL "jemalloc")
-  add_dependencies (core jemalloc_ext)
+  add_dependencies (core_static jemalloc_static)
+  add_dependencies (core_shared jemalloc_shared)
 endif()
 
 # --- Generate output ----------------------------------------------------------
@@ -368,18 +369,24 @@ endif()
 
 set (LIB_NAME ujit)
 
-set (LIB_OBJECTS
-  $<TARGET_OBJECTS:vm>
-  $<TARGET_OBJECTS:core>
-  $<TARGET_OBJECTS:libudis86>
+set (LIB_OBJECTS_STATIC
+  $<TARGET_OBJECTS:vm_static>
+  $<TARGET_OBJECTS:core_static>
+  $<TARGET_OBJECTS:libudis86_static>
+)
+
+set (LIB_OBJECTS_SHARED
+  $<TARGET_OBJECTS:vm_shared>
+  $<TARGET_OBJECTS:core_shared>
+  $<TARGET_OBJECTS:libudis86_shared>
 )
 
 if(UJIT_ALLOCATOR STREQUAL "jemalloc")
-  list(APPEND LIB_OBJECTS $<TARGET_OBJECTS:jemalloc>)
+  list(APPEND LIB_OBJECTS_STATIC $<TARGET_OBJECTS:jemalloc_static>)
+  list(APPEND LIB_OBJECTS_SHARED $<TARGET_OBJECTS:jemalloc_shared>)
 endif()
 
-# NB! Static library is built from PIC object files, too.
-add_library (libujit_static STATIC ${LIB_OBJECTS})
+add_library (libujit_static STATIC ${LIB_OBJECTS_STATIC})
 set_target_properties (libujit_static PROPERTIES
   OUTPUT_NAME ${LIB_NAME}
   COMPILE_FLAGS "${TARGET_C_FLAGS}"
@@ -392,7 +399,7 @@ if(NOT UJIT_TARGET_OS STREQUAL "UJ_TARGET_MACOS")
   # Otherwise assume they are supported.
   set(LIBUJIT_SHARED_LINK_FLAGS "${LIBUJIT_SHARED_LINK_FLAGS} -Wl,--version-script,${UJIT_SRC_DIR}/libujit.map")
 endif()
-add_library (libujit_shared SHARED ${LIB_OBJECTS})
+add_library (libujit_shared SHARED ${LIB_OBJECTS_SHARED})
 set_target_properties (libujit_shared PROPERTIES
   OUTPUT_NAME ${LIB_NAME}
   COMPILE_FLAGS "${TARGET_C_FLAGS}"


### PR DESCRIPTION
* Static library is built from non-PIC object files.
* Shared library is built from PIC object files.
* Corresponding changes are propagated to all dependencies.
* Updated build documentation.
* Introduced fixes in building `udis86` and Intel VTune JIT helper.
