### PR TITLE
Upgrade Clang Format version

### DIFF
--- a/.github/bootstrap/test-depends-22-04
+++ b/.github/bootstrap/test-depends-22-04
@@ -1,5 +1,5 @@
 bc
-clang-format-11
+clang-format-15
 clang-tidy-11
 gdb
 graphviz

--- a/scripts/run-clang-format
+++ b/scripts/run-clang-format
@@ -25,7 +25,7 @@ use constant {
 		verbose => 0,
 		clang_format => {
 			prefix => '/usr/bin/clang-format',
-			versions => [ qw(11) ],
+			versions => [ qw(15) ],
 		},
 	},
 	EXCLUDE => {


### PR DESCRIPTION
Clang Format is upgraded up to version 15.0.7 to make seamless migration from Ubuntu 22.04 to Ubuntu 24.04 (both distros provide the mentioned version of Clang toolchain from the default repositories). Further Clang toolchain upgrades will be completed after full migration to Ubuntu 24.04.

Signed-off-by: Igor Munkin <imun@cpan.org>