### PR TITLE
Upgrade to macOS 15 in GitHub Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         BUILDTYPE: [Debug, Release]
-        DISTVER: [13]
+        DISTVER: [15]
         include:
           - BUILDTYPE: Debug
             CMAKEFLAGS: >-
@@ -46,7 +46,7 @@ jobs:
           - BUILDTYPE: Release
             CMAKEFLAGS: >-
               -DCMAKE_BUILD_TYPE=Release
-    runs-on: macos-${{ matrix.DISTVER }}
+    runs-on: macos-${{ matrix.DISTVER }}-intel
     name: >-
       macOS ${{ matrix.DISTVER }}
       /

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,15 +37,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        BUILDTYPE: [Debug, Release]
+        # FIXME: Release build is excluded from the testing
+        # matrix, until #87 is resolved.
+        BUILDTYPE: [Debug]
         DISTVER: [15]
         include:
           - BUILDTYPE: Debug
             CMAKEFLAGS: >-
               -DCMAKE_BUILD_TYPE=Debug
-          - BUILDTYPE: Release
-            CMAKEFLAGS: >-
-              -DCMAKE_BUILD_TYPE=Release
     runs-on: macos-${{ matrix.DISTVER }}-intel
     name: >-
       macOS ${{ matrix.DISTVER }}


### PR DESCRIPTION
GitHub announced in actions/runner-images#13046 that `macos-13` has been deprecated and will no longer be available after 08.12.2025, so `macos-15-intel` runner will be used in uJIT CI as a result of the patch. It's worth to mention, that there is `macos-14` runner for x86_64 (even mentioned in macOS 13 deprecation blogpost[1]), but this image is not available for free GitHub plan. Hence, we are moving to `macos-15-intel`, that is the last macOS image available for x86_64 platform (see the deprecation policy described in actions/runner-images#13045).

As a result of the runner upgrade, uJIT smoke tests become broken for Release build. Hence, to preserve other macOS builds in uJIT CI, this flavor is excluded from the current testing matrix, until #87 is resolved.

[1]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down

Signed-off-by: Igor Munkin <imun.dev@gmail.com>